### PR TITLE
Allowing message headers

### DIFF
--- a/python_logging_rabbitmq/handlers.py
+++ b/python_logging_rabbitmq/handlers.py
@@ -17,7 +17,7 @@ class RabbitMQHandler(logging.Handler):
                  username=None, password=None,
                  exchange='log', declare_exchange=False,
                  routing_key_format="{name}.{level}", close_after_emit=False,
-                 fields=None, fields_under_root=True):
+                 fields=None, fields_under_root=True, message_headers=None):
         """
         Initialize the handler.
 
@@ -26,6 +26,7 @@ class RabbitMQHandler(logging.Handler):
         :param host:               RabbitMQ host. Default localhost
         :param port:               RabbitMQ Port. Default 5672
         :param connection_params:  Allow extra params to connect with RabbitMQ.
+        :param message_headers:    A dictionary of headers to be published with the message. Optional.
         :param username:           Username in case of authentication.
         :param password:           Password for the username.
         :param exchange:           Send logs using this exchange.
@@ -55,6 +56,9 @@ class RabbitMQHandler(logging.Handler):
 
         if username and password:
             self.connection_params['credentials'] = credentials.PlainCredentials(username, password)
+
+        # Extra params for message publication
+        self.message_headers = message_headers
 
         # Logging.
         self.formatter = formatter
@@ -121,7 +125,8 @@ class RabbitMQHandler(logging.Handler):
                 routing_key=routing_key,
                 body=self.format(record),
                 properties=pika.BasicProperties(
-                    delivery_mode=2
+                    delivery_mode=2,
+                    headers=self.message_headers
                 )
             )
 

--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -21,7 +21,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
                  username=None, password=None,
                  exchange='log', declare_exchange=False,
                  routing_key_format="{name}.{level}", close_after_emit=False,
-                 fields=None, fields_under_root=True):
+                 fields=None, fields_under_root=True, message_headers=None):
         """
         Initialize the handler.
 
@@ -30,6 +30,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
         :param host:               RabbitMQ host. Default localhost
         :param port:               RabbitMQ Port. Default 5672
         :param connection_params:  Allow extra params to connect with RabbitMQ.
+        :param message_headers:    A dictionary of headers to be published with the message. Optional.
         :param username:           Username in case of authentication.
         :param password:           Password for the username.
         :param exchange:           Send logs using this exchange.
@@ -59,6 +60,9 @@ class RabbitMQHandlerOneWay(logging.Handler):
 
         if username and password:
             self.connection_params['credentials'] = credentials.PlainCredentials(username, password)
+
+        # Extra params for message publication
+        self.message_headers = message_headers
 
         # Logging.
         self.formatter = formatter
@@ -135,7 +139,8 @@ class RabbitMQHandlerOneWay(logging.Handler):
                     routing_key=routing_key,
                     body=self.format(record),
                     properties=pika.BasicProperties(
-                        delivery_mode=2
+                        delivery_mode=2,
+                        headers=self.message_headers
                     )
                 )
             except Exception:


### PR DESCRIPTION
Hi,
I wanted to use your library for logging to RabbitMQ, but I needed message headers to be set on the messags (for use in the RabbitMQ-Logstash-plugin). This PR allows users to optionally specify message headers in init. If the user does not specify any, None is passed (which is the pika default, see http://pika.readthedocs.io/en/0.10.0/modules/spec.html#pika.spec.BasicProperties ).

I've tested this with both RabbitMQHandler and RabbitMQHandlerOneWay (using pika 0.11.2).

In case you think this may be useful for others users, feel free to (edit and/or) accept this PR.