### PR TITLE
call of channel.exchange_declare modified 

### DIFF
--- a/python_logging_rabbitmq/handlers.py
+++ b/python_logging_rabbitmq/handlers.py
@@ -92,7 +92,7 @@ class RabbitMQHandler(logging.Handler):
             self.channel = self.connection.channel()
 
         if self.exchange_declared is False:
-            self.channel.exchange_declare(exchange=self.exchange, type='topic', durable=True, auto_delete=False)
+            self.channel.exchange_declare(exchange=self.exchange, exchange_type='topic', durable=True, auto_delete=False)
             self.exchange_declared = True
 
         # Manually remove logger to avoid shutdown message.

--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -102,7 +102,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
                 self.channel = self.connection.channel()
 
             if self.exchange_declared is False:
-                self.channel.exchange_declare(exchange=self.exchange, type='topic', durable=True, auto_delete=False)
+                self.channel.exchange_declare(exchange=self.exchange, exchange_type='topic', durable=True, auto_delete=False)
                 self.exchange_declared = True
 
             # Manually remove logger to avoid shutdown message.


### PR DESCRIPTION
According to the Pika source at: https://github.com/pika/pika/blob/master/pika/channel.py#L658 the channel.exchange_declare method has no argument 'type', the corresponding argument is 'exchange_type'.