### PR TITLE
allow working with pika > 0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = [
-    'pika==0.10.0'
+    'pika>=0.10.0'
 ]
 
 setup(name='python-logging-rabbitmq',


### PR DESCRIPTION
0.12 is available now and is required for python 3.7.
Without this fix, pip warns about incompatibility.