### PR TITLE
Fix in publish(): the body is already formatted.

### DIFF
--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -146,7 +146,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
                 self.channel.basic_publish(
                     exchange=self.exchange,
                     routing_key=routing_key,
-                    body=self.format(record),
+                    body=record,
                     properties=pika.BasicProperties(
                         delivery_mode=2,
                         headers=self.message_headers


### PR DESCRIPTION
In emit(), the record is formatted and than queued.
The worker, is getting from the queue the record to be published
In publish(), that record was formatted again (a second time)

Try a simple app like this:

import time
import logging
from python_logging_rabbitmq import RabbitMQHandlerOneWay

logger = logging.getLogger('myapp')
logger.setLevel(logging.DEBUG)

rabbit = RabbitMQHandlerOneWay(host='localhost', port=5672)
logger.addHandler(rabbit)

logger.debug('test debug')
time.sleep(3)


--
Error:
File "python-logging-rabbitmq/python_logging_rabbitmq/formatters.py", line 22, in format
    data = record.__dict__.copy()
AttributeError: 'str' object has no attribute '__dict__'
