### PR TITLE
fix: handle thread shutdown

### DIFF
--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -175,6 +175,9 @@ class RabbitMQHandlerOneWay(logging.Handler):
         self.stopped.set()
 
     def emit(self, record):
+        if not hasattr(self, 'queue') or self.stopped.is_set():
+            return
+
         try:
             if self.routing_key_formatter:
                 routing_key = self.routing_key_formatter(record)
@@ -214,7 +217,8 @@ class RabbitMQHandlerOneWay(logging.Handler):
         """
         self.acquire()
 
-        del self.queue
+        if hasattr(self, 'queue'):
+            del self.queue
 
         try:
             self.close_connection()


### PR DESCRIPTION
Introduce two events (stopping, stopped) to interlock with
the worker thread and cause a graceful shutdown.

Add a timeout to the Queue get of 10s, this means that a graceful
shutdown will not be instantaneous.

Switch to `del` on the Pika blocking channels.