### PR TITLE
Call queue.task_done() only after a successful get()

### DIFF
--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -151,20 +151,28 @@ class RabbitMQHandlerOneWay(logging.Handler):
         while not self.stopping.is_set():
             try:
                 record, routing_key = self.queue.get(block=True, timeout=10)
+                
+                try:
 
-                if not self.connection or self.connection.is_closed or not self.channel or self.channel.is_closed:
-                    self.open_connection()
+                    if not self.connection or self.connection.is_closed or not self.channel or self.channel.is_closed:
+                        self.open_connection()
 
-                res = self.channel.basic_publish(
-                    exchange=self.exchange,
-                    routing_key=routing_key,
-                    body=record,
-                    properties=pika.BasicProperties(
-                        delivery_mode=2,
-                        headers=self.message_headers,
-                        content_type=self.content_type
+                    res = self.channel.basic_publish(
+                        exchange=self.exchange,
+                        routing_key=routing_key,
+                        body=record,
+                        properties=pika.BasicProperties(
+                            delivery_mode=2,
+                            headers=self.message_headers,
+                            content_type=self.content_type
+                        )
                     )
-                )
+                    
+                finally:
+                    self.queue.task_done()
+                    
+                    if self.close_after_emit:
+                        self.close_connection()
 
             except Queue.Empty:
                 continue
@@ -175,9 +183,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
                 if self.stopping.is_set():
                     self.stopped.set()
                     break
-                self.queue.task_done()
-                if self.close_after_emit:
-                    self.close_connection()
+                   
         self.stopped.set()
 
     def emit(self, record):


### PR DESCRIPTION
queue.task_done() should be called only when an item was actually returned by get(). If get() raises a Empty exception, task_done() should not be called.

Also, close the Pika connection only if it was actually opened.