### PR TITLE
Issue/43 add amqp url

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ These are the configuration allowed:
 | port                  | RabbitMQ Server port.                                                                                                                    | 5672                                  |
 | username              | Username for authentication.                                                                                                             | None                                  |
 | password              | Provide a password for the username.                                                                                                     | None                                  |
+| url                   | AMQP url to use instead of host/port/username/password.                                                                                  | None                                  |
 | exchange              | Name of the exchange to publish the logs. This exchange is considered of type topic.                                                     | log                                   |
 | declare_exchange      | Whether or not to declare the exchange.                                                                                                  | False                                 |
 | remove_request        | If True (default), remove request & exc info.                                                                                            | True                                  |
@@ -155,6 +156,7 @@ These are the configuration allowed:
 #### RabbitMQ Connection
 
 ```python
+# via host, port, username, password
 rabbit = RabbitMQHandler(
 	host='localhost',
 	port=5672,
@@ -165,6 +167,13 @@ rabbit = RabbitMQHandler(
 		'connection_attempts': 3,
 		'socket_timeout': 5000
 	}
+)
+```
+
+```python
+# via url
+rabbit = RabbitMQHandler(
+	url=amqps://guest:guest@example.host/vhost-example
 )
 ```
 

--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -20,7 +20,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
     """
     def __init__(self, level=logging.NOTSET, formatter=None,
         host='localhost', port=5672, connection_params=None,
-        username=None, password=None,
+        username=None, password=None, url=None,
         exchange='log', declare_exchange=False,
         remove_request=True,
         routing_key_format="{name}.{level}",
@@ -40,6 +40,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
         # :param message_headers:       A dictionary of headers to be published with the message. Optional.
         # :param username:              Username in case of authentication.
         # :param password:              Password for the username.
+        # :param url:                   AMQP url to be used instead of username/password/host/port.
         # :param exchange:              Send logs using this exchange.
         # :param declare_exchange:      Whether or not to declare the exchange.
         # :param remove_request:        If true (default), remove request/exc info
@@ -60,6 +61,7 @@ class RabbitMQHandlerOneWay(logging.Handler):
         self.exchange = exchange
         self.connection = None
         self.channel = None
+        self._url = url
         self.exchange_declared = not declare_exchange
         self.remove_request = remove_request
         self.routing_key_format = routing_key_format
@@ -119,7 +121,12 @@ class RabbitMQHandlerOneWay(logging.Handler):
 
             # Connect.
             if not self.connection or self.connection.is_closed:
-                self.connection = pika.BlockingConnection(pika.ConnectionParameters(**self.connection_params))
+                parameters = None
+                if self._url:
+                    parameters = pika.URLParameters(self._url)
+                else:
+                    parameters = pika.ConnectionParameters(**self.connection_params)
+                self.connection = pika.BlockingConnection(parameters)
 
             if not self.channel or self.channel.is_closed:
                 self.channel = self.connection.channel()


### PR DESCRIPTION
[Issue 43: RabbitMQHandler should be able to connect via a AMQP URL with URLParameters](https://github.com/albertomr86/python-logging-rabbitmq/issues/43)

This PR:
- Allows for `url` parameter in `RabbitMQHandler` & `RabbitMQHandlerOneWay` constructor to connect to `pika` connection via [AMQP URI](https://www.rabbitmq.com/uri-spec.html).
- Updates to README.md with examples.

Tested by:
- Running  local logger against a [CloudAMQP](https://cloudamqp.com) instance with/out url.

Example Test:
```python
import logging
from python_logging_rabbitmq import RabbitMQHandler
DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

logger = logging.getLogger(__name__)
formatter = logging.Formatter(DEFAULT_LOG_FORMAT)
rabbit_handler = RabbitMQHandler(
    url="...",
    exchange="...",
    routing_key_format="..."
)

rabbit_handler.setFormatter(formatter)
rabbit_handler.setLevel("INFO")
logger.addHandler(rabbit_handler)

logger.info("With url")

rabbit_handler = RabbitMQHandler(
    host="...",
    port=5672,
    username="...",
    password="...",
    connection_params={
	'virtual_host': '...',
    },
    exchange="...",
    routing_key_format="..."
)

rabbit_handler.setFormatter(formatter)
rabbit_handler.setLevel("INFO")
logger.addHandler(rabbit_handler)

logger.info("Without url")

```